### PR TITLE
Improve README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ InEveryLang is a somewhat-messy Middleman project. At the time I originally wrot
 
 But, it should run just like any other ruby/middleman project.
 
-1. Clone it
-2. `bundle install`
-3. `middleman`
+1. Install [Middleman](https://middlemanapp.com/basics/install/)
+2. Clone it
+3. `bundle install`
+4. `middleman`
 
 Those 3 simple steps should get you up and running on [your localhost](http://localhost:4567).
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ There's a couple things you have to do in order to add a brand new puzzle.
 
 3. Set the source in the frontmatter
 
-  If the code your submitting isn't yours, put a link here to wherever you got it from. If it is yours, this is your chance for some shameless self promotion - link to your portfolio, twitter, or a rickroll.
+  If the code you're submitting isn't yours, put a link here to wherever you got it from. If it is yours, this is your chance for some shameless self promotion - link to your portfolio, twitter, or a rickroll.
 
   **If you submit a solution attributed to yourself, and I find out that you are not the original source, I will remove your submission. I will also find some way to ruthlessly publicly shame you, because that's super not cool.**
 


### PR DESCRIPTION
Note, I still get an error when running "bundle install" on Windows, but I suspect it's probably an issue with version compatibility..

```
Using dotenv 1.0.2
with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    C:/Ruby21-x64/bin/ruby.exe extconf.rb
checking for main() in -lssl... no
checking for rb_trap_immediate in ruby.h,rubysig.h... no
checking for rb_thread_blocking_region()... yes
checking for inotify_init() in sys/inotify.h... no
checking for __NR_inotify_init in sys/syscall.h... no
checking for writev() in sys/uio.h... no
checking for rb_wait_for_single_fd()... yes
checking for rb_enable_interrupt()... no
checking for rb_time_new()... yes
checking for windows.h... yes
checking for winsock.h... yes
checking for main() in -lkernel32... yes
checking for main() in -lrpcrt4... yes
checking for main() in -lgdi32... yes
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
generating rubyeventmachine-x64-mingw32.def
compiling binder.cpp
In file included from c:/Ruby21-x64/include/ruby-2.1.0/ruby/defines.h:28:0,
                 from c:/Ruby21-x64/include/ruby-2.1.0/ruby/ruby.h:29,
                 from c:/Ruby21-x64/include/ruby-2.1.0/ruby.h:33,
                 from em.h:24,
                 from project.h:150,
                 from binder.cpp:20:
c:\tmp\ruby-devkit\mingw\bin\../lib/gcc/x86_64-w64-mingw32/4.7.2/../../../../x86_64-w64-mingw32/include/sys/types.h:68:1
6: error: conflicting declaration 'typedef _pid_t pid_t'
In file included from binder.cpp:20:0:
project.h:97:13: error: 'pid_t' has a previous declaration as 'typedef int pid_t'
In file included from project.h:151:0,
                 from binder.cpp:20:
ed.h: In member function 'void EventableDescriptor::SetSocketInvalid()':
ed.h:43:40: warning: overflow in implicit constant conversion [-Woverflow]
make: *** [binder.o] Error 1

make failed, exit code 2

Gem files will remain installed in C:/Ruby21-x64/lib/ruby/gems/2.1.0/gems/eventmachine-1.0.3 for inspection.
Results logged to C:/Ruby21-x64/lib/ruby/gems/2.1.0/extensions/x64-mingw32/2.1.0/eventmachine-1.0.3/gem_make.out
An error occurred while installing eventmachine (1.0.3), and Bundler cannot
continue.
Make sure that `gem install eventmachine -v '1.0.3'` succeeds before bundling.

```
